### PR TITLE
Introduces saving and loading directly to FS/File

### DIFF
--- a/src/NeuralNetwork.h
+++ b/src/NeuralNetwork.h
@@ -1762,7 +1762,7 @@ public:
     
 
     #if defined(SUPPORTS_SD_FUNCTIONALITY)
-        bool NeuralNetwork::save(File myFile)
+        bool NeuralNetwork::save(File& myFile)
         {
             if (myFile){
                 #if defined(REDUCE_RAM_WEIGHTS_LVL2)
@@ -1854,7 +1854,7 @@ public:
         }
 
 
-        bool NeuralNetwork::load(File myFile) {
+        bool NeuralNetwork::load(File& myFile) {
             if (numberOflayers !=0 || isAlreadyLoadedOnce) // to prevent undefined delete[] and memory leaks for the sake of reloading as many times as you want :)
                 pdestract();
 

--- a/src/NeuralNetwork.h
+++ b/src/NeuralNetwork.h
@@ -64,7 +64,7 @@
 #define __NN_VERSION__ "VERSION: 3.0.0"\n
 
 // - That gives you access to the standard types and constants of the Arduino language.
-#include "Arduino.h"
+// #include "Arduino.h"
 
 // https://arduino.stackexchange.com/questions/94743/is-ifdef-sd-h-considered-a-bad-practice/
 // considering there's a scope it's looking for the library if you declare it above the #include <NeuralNetwork.h> it will enable the functionality else no.. meaning that I don't need to worry about destructor optimization #8
@@ -1189,11 +1189,11 @@ public:
 
     #if defined(SUPPORTS_SD_FUNCTIONALITY)
         NeuralNetwork(String file);
-        NeuralNetwork(File file);
+        NeuralNetwork(File& file);
         bool save    (String file); // TODO: load\Save from RAM and PROGMEM, EEPROM, FRAM and other medias
-        bool save    (File file);
+        bool save    (File& file);
         bool load    (String file);
-        bool load    (File file);
+        bool load    (File& file);
         bool save_old(String file); // [OLD V.2.X.X] For migration to V3.0.0 or backwards compatibility
         bool load_old(String file); // [OLD V.2.X.X] For migration to V3.0.0 or backwards compatibility
     #endif
@@ -1238,7 +1238,7 @@ public:
             load(file);
         }
 
-        NeuralNetwork::NeuralNetwork(File file){
+        NeuralNetwork::NeuralNetwork(File& file){
             #if defined(SUPPORTS_SD_FUNCTIONALITY) || !defined(NO_BACKPROP) || defined(RAM_EFFICIENT_HILL_CLIMB) // #8
                 isAllocdWithNew = false;
             #endif


### PR DESCRIPTION
Hello Giorgos,

First, I'd like to thank you for this awesome library, it's allowing our research at out facility. I'm already working with this modified version of the library due to our needs, and I thought to contribute just a tiny bit back by pushing it here.

We are reading and writing directly to an ESP32 partition, which we are accessing via SPIFFS since we have no SD adaptar running on them. Since the saving and loading functionality is already there, I adapted to the NN library being able to handle inputs directly from a `File` inputted by the library consumer. That way, any other `FS/File` can be submitted to properly work.

Also, since whoever created the file passes it downstream, I thought it should be their responsibility to close the stream after the call. Since the library did not create the memory object, it should not be responsible to close it down.

Please let me know what you think of this.

I also think that those methods maybe should be under a flag `SUPPORTS_FS_FUNCTIONALITY` and just load FS.h directly without loading SD.h, but I'd like to hear back from you first! 